### PR TITLE
Blog Support

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,3 +5,4 @@ SMTP_PASSWORD="password"
 SMTP_TO="to@example.com"
 ALLOWED_ORIGINS="example.com"
 PORT=8080
+FLATNOTES_URL="http://flatnotes:8080"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ go.work.sum
 
 # env file
 .env
+docker-compose.tests.yml
+Dockerfile.tests
+tests
+data

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/MonkaKokosowa/backend-flour/internal/env"
 	"github.com/MonkaKokosowa/backend-flour/internal/mail"
+	"github.com/MonkaKokosowa/backend-flour/internal/proxy"
 	"github.com/MonkaKokosowa/backend-flour/internal/web"
 	"github.com/rs/zerolog/log"
 )
@@ -14,8 +15,9 @@ func main() {
 
 	}
 	app := &web.App{
-		Env:    &environment,
-		Dialer: mail.GetDialer(environment),
+		Env:            &environment,
+		Dialer:         mail.GetDialer(environment),
+		FlatnotesProxy: proxy.NewProxy(environment.Blog.FlatnotesURL),
 	}
 
 	web.StartWeb(*app)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,18 @@ services:
       - "4324:${PORT}"
 
     restart: unless-stopped
+  flatnotes:
+    container_name: flatnotes
+    image: dullage/flatnotes:latest
+    environment:
+      PUID: 1000
+      PGID: 1000
+      FLATNOTES_AUTH_TYPE: "none"
+      FLATNOTES_SECRET_KEY: "aLongRandomSeriesOfCharacters"
+    volumes:
+      - "./data:/data"
+        # Optional. Allows you to save the search index in a different location:
+        # - "./index:/data/.flatnotes"
+    ports:
+      - "8280:8080"
+    restart: unless-stopped

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -17,6 +17,9 @@ type Environment struct {
 		AllowedOrigins string `env:"ALLOWED_ORIGINS,required"`
 		Port           int    `env:"PORT,required"`
 	}
+	Blog struct {
+		FlatnotesURL string `env:"FLATNOTES_URL,required"`
+	}
 }
 
 // GetEnv initializes environment variables from .env file (if present) and returns them

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,28 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/rs/zerolog/log"
+)
+
+// NewProxy creates a new reverse proxy for a target URL.
+func NewProxy(target string) *httputil.ReverseProxy {
+	targetURL, err := url.Parse(target)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Could not parse target URL")
+	}
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+
+	// Override the director if you need to modify the request further.
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		// You can modify req here.
+		// it's already in req.URL.Path.
+	}
+
+	return proxy
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -27,6 +27,11 @@ type MailWebRequest struct {
 }
 
 func (a *App) blogProxy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		log.Error().Msg("Method not allowed")
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	proxy := proxy.NewProxy(a.Env.Blog.FlatnotesURL)
 	proxy.ServeHTTP(w, r)
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -4,20 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"strings"
 
 	"github.com/rs/zerolog/log"
 
 	env "github.com/MonkaKokosowa/backend-flour/internal/env"
 	"github.com/MonkaKokosowa/backend-flour/internal/mail"
-	"github.com/MonkaKokosowa/backend-flour/internal/proxy"
 	"github.com/rs/cors"
 	"gopkg.in/gomail.v2"
 )
 
 type App struct {
-	Env    *env.Environment
-	Dialer *gomail.Dialer
+	Env            *env.Environment
+	Dialer         *gomail.Dialer
+	FlatnotesProxy *httputil.ReverseProxy
 }
 
 type MailWebRequest struct {
@@ -32,8 +33,8 @@ func (a *App) blogProxy(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	flatnotesProxy := proxy.NewProxy(a.Env.Blog.FlatnotesURL)
-	flatnotesProxy.ServeHTTP(w, r)
+
+	a.FlatnotesProxy.ServeHTTP(w, r)
 }
 
 func (a *App) mailHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -10,6 +10,7 @@ import (
 
 	env "github.com/MonkaKokosowa/backend-flour/internal/env"
 	"github.com/MonkaKokosowa/backend-flour/internal/mail"
+	"github.com/MonkaKokosowa/backend-flour/internal/proxy"
 	"github.com/rs/cors"
 	"gopkg.in/gomail.v2"
 )
@@ -23,6 +24,11 @@ type MailWebRequest struct {
 	Name    string `json:"name"`
 	Mail    string `json:"email"`
 	Message string `json:"message"`
+}
+
+func (a *App) blogProxy(w http.ResponseWriter, r *http.Request) {
+	proxy := proxy.NewProxy(a.Env.Blog.FlatnotesURL)
+	proxy.ServeHTTP(w, r)
 }
 
 func (a *App) mailHandler(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +59,9 @@ func StartWeb(app App) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mail", app.mailHandler)
+	mux.HandleFunc("/api/notes/", app.blogProxy)
+	mux.HandleFunc("/api/attachments/", app.blogProxy)
+	mux.HandleFunc("/api/search", app.blogProxy)
 	// Configure CORS
 	c := cors.New(cors.Options{
 		AllowedOrigins:   strings.Split(app.Env.WebServer.AllowedOrigins, ","), // Adjust this to your frontend's origin

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -27,7 +27,7 @@ type MailWebRequest struct {
 	Message string `json:"message"`
 }
 
-func (a *App) blogProxy(w http.ResponseWriter, r *http.Request) {
+func (a *App) blogProxyHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		log.Error().Msg("Method not allowed")
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -65,9 +65,9 @@ func StartWeb(app App) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mail", app.mailHandler)
-	mux.HandleFunc("/api/notes/", app.blogProxy)
-	mux.HandleFunc("/api/attachments/", app.blogProxy)
-	mux.HandleFunc("/api/search", app.blogProxy)
+	mux.HandleFunc("/api/notes/", app.blogProxyHandler)
+	mux.HandleFunc("/api/attachments/", app.blogProxyHandler)
+	mux.HandleFunc("/api/search", app.blogProxyHandler)
 	// Configure CORS
 	c := cors.New(cors.Options{
 		AllowedOrigins:   strings.Split(app.Env.WebServer.AllowedOrigins, ","), // Adjust this to your frontend's origin

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -32,8 +32,8 @@ func (a *App) blogProxy(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	proxy := proxy.NewProxy(a.Env.Blog.FlatnotesURL)
-	proxy.ServeHTTP(w, r)
+	flatnotesProxy := proxy.NewProxy(a.Env.Blog.FlatnotesURL)
+	flatnotesProxy.ServeHTTP(w, r)
 }
 
 func (a *App) mailHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR adds basic support to the backend for using flatnotes as engine for markdown blog, which will then be retrieved on the frontend and converted to html on the fly. It uses docker networks and Golang proxy to securely pass through only blog data, without exposing flatnotes service to public network.